### PR TITLE
Add Healthchecks.io Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,14 @@ sudo journalctl -f -u snapshot.service
 
 ### Available Parameters
 
-| Parameter     | Type   | Required | Description                                     |
-|---------------|--------|----------|-------------------------------------------------|
-| -b,--bucket   | String | Yes      | S3 Bucket name                                  |
-| -e,--endpoint | String | Yes      | S3 endpoint URL                                 |
-| -i,--id       | String | Yes      | The S3 tenant ID                                |
-| -n,--network  | String | Yes      | The cosmos-sdk network name                     |
-| -d,--daemon   | String | Yes      | The folder location of the daemon data          |
-| -u,--userdir  | String | Yes      | The user's home directory                       |
-| -h,--help     | None   | No       | Help for the Crypto Chemistry Snapshot Uploader |
+| Parameter            | Type   | Required | Description                                     |
+|----------------------|--------|----------|-------------------------------------------------|
+| -b,--bucket          | String | Yes      | S3 Bucket name                                  |
+| -e,--endpoint        | String | Yes      | S3 endpoint URL                                 |
+| -i,--id              | String | Yes      | The S3 tenant ID                                |
+| -n,--network         | String | Yes      | The cosmos-sdk network name                     |
+| -d,--daemon          | String | Yes      | The folder location of the daemon data          |
+| -u,--userdir         | String | Yes      | The user's home directory                       |
+| -p,--healthcheck     | None   | No       | Enable health checks (uses ${HEALTHCHECKS_URL} if -c is not specified)|
+| -c,--healthcheck_url | String | No       | The healthchecks.io URL to send health checks   |
+| -h,--help            | None   | No       | Help for the Crypto Chemistry Snapshot Uploader |

--- a/create_new_healthcheck.sh
+++ b/create_new_healthcheck.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+
+API_KEY=
+HEALTHCHECK_URL=
+
+# Create payload. Daily timeout, 2 hour grace period
+PAYLOAD='{"name": "'$(hostname)'", "timeout": 86400, "grace": 7200, "unique": ["name"]}'
+
+# Creates the payload if non-existent
+# Returns the URL to ping
+URL=$(curl -s $HEALTHCHECK_URL -H "X-Api-Key: $API_KEY" -d "$PAYLOAD" | jq -r .ping_url)
+
+# Send a ping
+curl -m 10 --retry 5 $URL
+
+if [[ ! -z ${HEALTHCHECK_URL} ]]; then
+    echo "export HEALTHCHECK_URL=$URL" >> $HOME/.bashrc
+    source $HOME/.bashrc
+fi
+
+exit 0


### PR DESCRIPTION
Introduces the -c and -p flags to enable healthcheck pings to either healthchecks.io or a self-hosted instance of it. Addresses #7 