### PR TITLE
Add state-sync functionality to reduce snapshot size

### DIFF
--- a/snapshot.service.j2
+++ b/snapshot.service.j2
@@ -10,7 +10,8 @@ ExecStart={{ user_dir }}/cosmos-snapshot/snapshot.sh \
             -n {{ network }} \
             -d {{ snapshot_daemon_dir }} \
             -u "{{ user_dir }}" \
-            --healthcheck_url "{{ snapshot_healthcheck_url }}"
+            --healthcheck_url "{{ snapshot_healthcheck_url }}" \
+            -p
 
 [Install]
 WantedBy=default.target

--- a/snapshot.service.j2
+++ b/snapshot.service.j2
@@ -4,12 +4,13 @@ Description=Snapshot Upload Service
 [Service]
 Type=simple
 ExecStart={{ user_dir }}/cosmos-snapshot/snapshot.sh \
-            -b {{ s3_bucket_name }} \
-            -e "{{ s3_endpoint }}" \
-            -i "{{ s3_tenant_id }}" \
-            -n {{ chain_name }} \
-            -d {{ daemon_dir }} \
-            -u "{{ user_dir }}"
+            -b {{ snapshot_s3_bucket_name }} \
+            -e "{{ snapshot_s3_endpoint }}" \
+            -i "{{ snapshot_s3_tenant_id }}" \
+            -n {{ network }} \
+            -d {{ snapshot_daemon_dir }} \
+            -u "{{ user_dir }}" \
+            --healthcheck_url "{{ snapshot_healthcheck_url }}"
 
 [Install]
 WantedBy=default.target

--- a/state-sync/README.md
+++ b/state-sync/README.md
@@ -1,0 +1,34 @@
+# Crypto Chemistry - Cosmos Snapshot State-Sync Scripts
+
+### About
+
+This portion of the repo configures periodic state-syncs on a snapshot node to reduce the total snapshot size. As a result, much less storage space is required long-term for running a snapshot node for any given
+
+### Available Parameters
+
+  -r, --rpc string              (Required) The RPC server to state-sync with
+  -n, --network string          (Required) The cosmos-sdk network name
+  -d, --daemon string           (Required) The folder location of the daemon data
+  -u, --userdir                 (Required) The user's home director
+  --user                        (Required) The user that should own the tendermint data directory
+  -p, --healthcheck             (Optional) Enables sending Healthcheck pings
+  -c, --healthcheck_url         (Optional) Sets the Healtcheck URL to ping
+  -s, --service                 (Optional) The service name that controls the chain's deamon
+  -h, --help                    (Optional) Help for the Crypto Chemistry Snapshot Uploader
+
+| Parameter            | Type   | Required | Description                                     |
+|----------------------|--------|----------|-------------------------------------------------|
+| -r, --rpc            | String | Yes      | The RPC server to state-sync with               |
+| -n,--network         | String | Yes      | The cosmos-sdk network name                     |
+| -d,--daemon          | String | Yes      | The chain's daemon name (kujirad, strided, etc) |
+| -u,--userdir         | String | Yes      | The user's home directory                       |
+| --user               | String | Yes      | The user that should own the Tendermint data directory|
+| -p,--healthcheck     | None   | No       | Enables sending Healthcheck pings               |
+| -c,--healthcheck_url | String | No       | Sets the Healtcheck URL to ping                 |
+| -s,--service         | String | No       | The service name that controls the chain's deamon (defaults to cosmovisor.service)|
+| -h,--help            | None   | No       | Help for the Crypto Chemistry Snapshot Uploader |
+
+## State-Sync Usage
+All state-sync related scripts and services can be found in the `state-sync/` directory.
+
+The `snapshot_state_sync.service.j2` script needs to be edited to provide user, path to the `snapshot_state_sync.sh` script, and optionally the healthcheck url.

--- a/state-sync/create_new_ss_healthcheck.sh
+++ b/state-sync/create_new_ss_healthcheck.sh
@@ -13,8 +13,8 @@ URL=$(curl -s $HEALTHCHECK_URL -H "X-Api-Key: $API_KEY" -d "$PAYLOAD" | jq -r .p
 # Send a ping
 curl -m 10 --retry 5 $URL
 
-if [[ ! -z ${HEALTHCHECK_URL} ]]; then
-    echo "export HEALTHCHECK_URL=$URL" >> $HOME/.bashrc
+if [[ ! -z ${STATE_SYNC_HEALTHCHECK_URL} ]]; then
+    echo "export STATE_SYNC_HEALTHCHECK_URL=$URL" >> $HOME/.bashrc
     source $HOME/.bashrc
 fi
 

--- a/state-sync/create_new_ss_healthcheck.sh
+++ b/state-sync/create_new_ss_healthcheck.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+
+API_KEY=
+HEALTHCHECK_URL=
+
+# Create payload. Daily timeout, 2 hour grace period
+PAYLOAD='{"name": "'$(hostname)'-state-sync", "timeout": 86400, "grace": 7200, "unique": ["name"]}'
+
+# Creates the payload if non-existent
+# Returns the URL to ping
+URL=$(curl -s $HEALTHCHECK_URL -H "X-Api-Key: $API_KEY" -d "$PAYLOAD" | jq -r .ping_url)
+
+# Send a ping
+curl -m 10 --retry 5 $URL
+
+if [[ ! -z ${HEALTHCHECK_URL} ]]; then
+    echo "export HEALTHCHECK_URL=$URL" >> $HOME/.bashrc
+    source $HOME/.bashrc
+fi
+
+exit 0

--- a/state-sync/snapshot_state_sync.service.j2
+++ b/state-sync/snapshot_state_sync.service.j2
@@ -6,6 +6,7 @@ Type=simple
 User={{ user }}
 Group={{ user }}
 ExecStart={{ path_to_state_sync_script }}
+Environment=STATE_SYNC_HEALTHCHECK_URL={{ state_sync_healthcheck }}
 
 [Install]
 WantedBy=default.target

--- a/state-sync/snapshot_state_sync.service.j2
+++ b/state-sync/snapshot_state_sync.service.j2
@@ -12,7 +12,8 @@ ExecStart={{ user_dir }}/cosmos-snapshot/state-sync/snapshot_state_sync.sh \
 	--userdir {{ user_dir }} \
 	--user {{ validator_user }} \
 	--service {{ state_sync_daemon_service }} \
-	--healthcheck_url {{ state_sync_healthcheck_url }}
+	--healthcheck_url {{ state_sync_healthcheck_url }} \
+	-p
 
 [Install]
 WantedBy=default.target

--- a/state-sync/snapshot_state_sync.service.j2
+++ b/state-sync/snapshot_state_sync.service.j2
@@ -3,8 +3,8 @@ Description=Snapshot State-Sync Service
 
 [Service]
 Type=simple
-User={{ validator_user }}
-Group={{ validator_user }}
+User=root
+Group=root
 ExecStart={{ user_dir }}/cosmos-snapshot/state-sync/snapshot_state_sync.sh \
 	--rpc "{{ state_sync_rpc }}" \
 	--network {{ network }} \

--- a/state-sync/snapshot_state_sync.service.j2
+++ b/state-sync/snapshot_state_sync.service.j2
@@ -3,10 +3,16 @@ Description=Snapshot State-Sync Service
 
 [Service]
 Type=simple
-User={{ user }}
-Group={{ user }}
-ExecStart={{ path_to_state_sync_script }}
-Environment=STATE_SYNC_HEALTHCHECK_URL={{ state_sync_healthcheck }}
+User={{ validator_user }}
+Group={{ validator_user }}
+ExecStart={{ user_dir }}/cosmos-snapshot/state-sync/snapshot_state_sync.sh \
+	--rpc "{{ state_sync_rpc }}" \
+	--network {{ network }} \
+	--daemon {{ user_dir }}/go/bin/{{ daemon }} \
+	--userdir {{ user_dir }} \
+	--user {{ validator_user }} \
+	--service {{ state_sync_daemon_service }} \
+	--healthcheck_url {{ state_sync_healthcheck_url }}
 
 [Install]
 WantedBy=default.target

--- a/state-sync/snapshot_state_sync.service.j2
+++ b/state-sync/snapshot_state_sync.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Snapshot State-Sync Service
+
+[Service]
+Type=simple
+User={{ user }}
+Group={{ user }}
+ExecStart={{ path_to_state_sync_script }}
+
+[Install]
+WantedBy=default.target

--- a/state-sync/snapshot_state_sync.sh
+++ b/state-sync/snapshot_state_sync.sh
@@ -108,8 +108,8 @@ disable_state_sync() {
 }
 
 healthcheck() {
-    printf "\n==> %s\n" "Sending healthcheck to ${STATE_SYNC_HEALTHCHECK_URL}"
-    if [[ ! -z ${HEALTHCHECK} && ! -z ${STATE_SYNC_STATE_SYNC_HEALTHCHECK_URL} ]]; then
+    if [[ ! -z ${HEALTHCHECK} && ! -z ${STATE_SYNC_HEALTHCHECK_URL} ]]; then
+        printf "\n==> %s\n" "Sending healthcheck to ${STATE_SYNC_HEALTHCHECK_URL}"
         curl -m 10 --retry 5 ${STATE_SYNC_HEALTHCHECK_URL}
     fi
 }

--- a/state-sync/snapshot_state_sync.sh
+++ b/state-sync/snapshot_state_sync.sh
@@ -34,7 +34,7 @@ make_opts() {
 parse_args() {
     while true; do
     case "$1" in
-        -r | --rpc ) RPC="$2"; shift 2 ;;
+        -r | --rpc ) RPC="${2%/}"; shift 2 ;;
         -n | --network ) NETWORK="$2"; shift 2 ;;
         -d | --daemon ) DAEMON="$2"; shift 2 ;;
         -u | --userdir ) USER_DIR="$2"; shift 2 ;;
@@ -67,7 +67,7 @@ parse_args() {
 
 configure_state_sync() {
     #Stop daemon service
-    sudo systemctl stop ${SERVICE}
+    systemctl stop ${SERVICE}
     
     #Reset data
     printf "\n==> %s\n" "Resetting ${NETWORK} chain data"
@@ -89,7 +89,7 @@ configure_state_sync() {
 
 sync_server() {
     printf "\n==> %s\n" "Starting state-sync"
-    sudo systemctl start ${SERVICE}
+    systemctl start ${SERVICE}
     sleep 5
     #Check if still syncing
     while [[ $(${DAEMON} status 2> /dev/null | jq .SyncInfo.catching_up) != "false" ]]; do

--- a/state-sync/snapshot_state_sync.sh
+++ b/state-sync/snapshot_state_sync.sh
@@ -1,0 +1,122 @@
+#!/bin/bash -e
+
+# # # # #
+# Init vars:
+SCRIPT_NAME="$(basename $0)"
+
+# # # # #
+# Init funcs:
+help_menu() {
+    printf "\
+  Crypto Chemistry State Sync Service
+  Usage: snapshot_state_sync.sh [FLAGS]
+
+  Flags:
+  -r, --rpc string              (Required) The RPC server to state-sync with
+  -n, --network string          (Required) The cosmos-sdk network name
+  -d, --daemon string           (Required) The folder location of the daemon data
+  -u, --userdir                 (Required) The user's home director
+  -p, --healthcheck             (Optional) Enables sending Healthcheck pings
+  -c, --healthcheck_url         (Optional) Sets the Healtcheck URL to ping
+  -s, --service                 (Optional) The service name that controls the chain's deamon
+  -h, --help                    (Optional) Help for the Crypto Chemistry Snapshot Uploader
+"
+}
+
+make_opts() {
+    # getopt boilerplate for argument parsing
+    local _OPTS=$(getopt -o r:n:d:u:s:pc:h --long rpc:,network:,daemon:,userdir:,service:,healthcheck,healthcheck_url:,help \
+            -n 'Crypto Chemistry Snapshot State-Sync' -- "$@")
+    [[ $? != 0 ]] && { echo "Terminating..." >&2; exit 51; }
+    eval set -- "${_OPTS}"
+}
+
+parse_args() {
+    while true; do
+    case "$1" in
+        -r | --rpc ) RPC="$2"; shift 2 ;;
+        -n | --network ) NETWORK="$2"; shift 2 ;;
+        -d | --daemon ) DAEMON="$2"; shift 2 ;;
+        -u | --userdir ) USER_DIR="$2"; shift 2 ;;
+        -s | --service ) SERVICE="$2"; shift 2 ;;
+        -p | --healthcheck ) HEALTHCHECK="True"; shift ;;
+        -c | --healthcheck_url ) STATE_SYNC_HEALTHCHECK_URL="$2"; shift 2 ;;
+        -h | --help ) HELP_MENU="True"; shift ;;
+        -- ) shift; break ;;
+        * ) break ;;
+    esac
+    done
+
+    [[ ! -z $HELP_MENU ]] && { help_menu; exit 0; }
+
+    if [[ -z $RPC || -z $NETWORK || -z $DAEMON || -z $USER_DIR ]]; then
+        printf "\
+        ${SCRIPT_NAME}: Error - Missing Arguments
+        The following arguments are required:
+            -r, --rpc
+            -n, --network
+            -d, --daemon
+            -u, --userdir
+    "
+        exit 52
+    fi
+    if [[ -z $SERVICE ]]; then
+        SERVICE="cosmovisor.service"
+    fi
+}
+
+configure_state_sync() {
+    #Stop daemon service
+    sudo systemctl stop ${SERVICE}
+    
+    #Reset data
+    printf "\n==> %s\n" "Resetting ${NETWORK} chain data"
+    ${DAEMON} tendermint unsafe-reset-all --home ${USER_DIR}/.${NETWORK} > /dev/null || \
+    ${DAEMON} unsafe-reset-all > /dev/null || \
+    (printf "\n==> %s\n" "Unable to delete chain data" && exit 51)
+
+
+    #Configure State Sync Settings
+    LATEST_HEIGHT=$(curl -s $RPC/block | jq -r .result.block.header.height); \
+    BLOCK_HEIGHT=$((LATEST_HEIGHT - 2000)); \
+    TRUST_HASH=$(curl -s "$RPC/block?height=$BLOCK_HEIGHT" | jq -r .result.block_id.hash)
+
+    sed -i.bak -E "s|^(enable[[:space:]]+=[[:space:]]+).*$|\1true| ; \
+    s|^(rpc_servers[[:space:]]+=[[:space:]]+).*$|\1\"$RPC,$RPC\"| ; \
+    s|^(trust_height[[:space:]]+=[[:space:]]+).*$|\1$BLOCK_HEIGHT| ; \
+    s|^(trust_hash[[:space:]]+=[[:space:]]+).*$|\1\"$TRUST_HASH\"|" ${USER_DIR}/.${NETWORK}/config/config.toml
+}
+
+sync_server() {
+    printf "\n==> %s\n" "Starting state-sync"
+    sudo systemctl start ${SERVICE}
+    sleep 5
+    #Check if still syncing
+    while [[ $(${DAEMON} status 2> /dev/null | jq .SyncInfo.catching_up) != "false" ]]; do
+        printf "\n==> %s\n" "Node is still syncing. Sleeping for 30 seconds."
+        sleep 30
+    done
+    printf "\n==> %s\n" "State Sync is complete"
+}
+
+disable_state_sync() {
+    printf "\n==> %s\n" "Disabling State-Sync in ${USER_DIR}/.${NETWORK}/config/config.toml"
+    sed -i.bak -E "s|^(enable[[:space:]]+=[[:space:]]+).*$|\1false|" ${USER_DIR}/.${NETWORK}/config/config.toml
+}
+
+healthcheck() {
+    printf "\n==> %s\n" "Sending healthcheck to ${STATE_SYNC_HEALTHCHECK_URL}"
+    if [[ ! -z ${HEALTHCHECK} && ! -z ${STATE_SYNC_STATE_SYNC_HEALTHCHECK_URL} ]]; then
+        curl -m 10 --retry 5 ${STATE_SYNC_HEALTHCHECK_URL}
+    fi
+}
+
+# # # # #
+# Main:
+make_opts
+parse_args "${@}"
+configure_state_sync
+sync_server
+disable_state_sync
+healthcheck
+exit "${?}"

--- a/state-sync/snapshot_state_sync.sh
+++ b/state-sync/snapshot_state_sync.sh
@@ -16,6 +16,7 @@ help_menu() {
   -n, --network string          (Required) The cosmos-sdk network name
   -d, --daemon string           (Required) The folder location of the daemon data
   -u, --userdir                 (Required) The user's home director
+  --user                        (Required) The user that should own the tendermint data directory
   -p, --healthcheck             (Optional) Enables sending Healthcheck pings
   -c, --healthcheck_url         (Optional) Sets the Healtcheck URL to ping
   -s, --service                 (Optional) The service name that controls the chain's deamon
@@ -25,7 +26,7 @@ help_menu() {
 
 make_opts() {
     # getopt boilerplate for argument parsing
-    local _OPTS=$(getopt -o r:n:d:u:s:pc:h --long rpc:,network:,daemon:,userdir:,service:,healthcheck,healthcheck_url:,help \
+    local _OPTS=$(getopt -o r:n:d:u:s:pc:h --long rpc:,network:,daemon:,userdir:,user:,service:,healthcheck,healthcheck_url:,help \
             -n 'Crypto Chemistry Snapshot State-Sync' -- "$@")
     [[ $? != 0 ]] && { echo "Terminating..." >&2; exit 51; }
     eval set -- "${_OPTS}"
@@ -38,6 +39,7 @@ parse_args() {
         -n | --network ) NETWORK="$2"; shift 2 ;;
         -d | --daemon ) DAEMON="$2"; shift 2 ;;
         -u | --userdir ) USER_DIR="$2"; shift 2 ;;
+        --user ) USER="$2"; shift 2 ;;
         -s | --service ) SERVICE="$2"; shift 2 ;;
         -p | --healthcheck ) HEALTHCHECK="True"; shift ;;
         -c | --healthcheck_url ) STATE_SYNC_HEALTHCHECK_URL="$2"; shift 2 ;;
@@ -74,6 +76,7 @@ configure_state_sync() {
     ${DAEMON} tendermint unsafe-reset-all --home ${USER_DIR}/.${NETWORK} > /dev/null || \
     ${DAEMON} unsafe-reset-all > /dev/null || \
     (printf "\n==> %s\n" "Unable to delete chain data" && exit 51)
+    chown -R ${USER}:${USER} ${USER_DIR}/.${NETWORK}
 
 
     #Configure State Sync Settings

--- a/state-sync/snapshot_state_sync.timer
+++ b/state-sync/snapshot_state_sync.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Snapshot Service on Schedule
+RefuseManualStart=no
+RefuseManualStop=no
+
+[Timer]
+Persistent=true
+OnCalendar=*-*-* 06:00:00
+Unit=snapshot_state_sync.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Adds the `state-sync` folder which includes service files and a script to automate resetting the snapshot node's chain data, state sync it, and resume the chain daemon service. After some initial testing I'm seeing Kujira mainnet snapshots at around 1.4GB and Stride at 300MB.